### PR TITLE
Added github publishing files

### DIFF
--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -1,0 +1,47 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will build a package using Gradle and then publish it to GitHub packages when a release is created
+# For more information see: https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#Publishing-using-gradle
+
+name: Gradle Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: set execute permissions for gradlew
+        run: chmod +x gradlew
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
+          settings-path: ${{ github.workspace }} # location for the settings.xml file
+
+      - name: Build with Gradle
+        uses: gradle/actions/setup-gradle@v3
+        with:
+          arguments: build
+
+      # The USERNAME and TOKEN need to correspond to the credentials environment variables used in
+      # the publishing section of your build.gradle
+      - name: Publish to GitHub Packages
+        uses: gradle/actions/setup-gradle@v3
+        with:
+          arguments: publish
+        env:
+          USERNAME: ${{ github.actor }}
+          TOKEN: ${{ secrets.PERSONAL_WRITE_TOKEN }}

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,0 +1,44 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will build a Java project with Gradle and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-gradle
+
+name: Java CI with Gradle
+
+on:
+  push
+
+permissions:
+  contents: read
+  issues: read
+  checks: write
+  pull-requests: write
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set execute permissions for Gradlew
+        run: chmod +x gradlew
+      - name: Check file permissions
+        run: ls -la gradlew
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+      - name: Build with Gradle
+        uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
+        with:
+          arguments: build
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: always()
+        with:
+          files: |
+            ./build/test-results/**/*.xml


### PR DESCRIPTION
This pull request introduces two new GitHub workflows to automate the build and publish processes for a Java project using Gradle. The most significant changes are the creation of the `gradle-publish.yml` and `gradle.yml` workflows, which are designed to automate the project's build and release processes.

GitHub workflows:

* [`.github/workflows/gradle-publish.yml`](diffhunk://#diff-2511803f9c29912d7f11dea9dade7a2272cfe322c681a8bff3727044db19e633R1-R47): This workflow is triggered when a new release is created. It builds the project using Gradle and then publishes the package to GitHub Packages. The workflow runs on the latest version of Ubuntu and requires read permissions for contents and write permissions for packages. It also sets up JDK 17 and uses the `actions/setup-java` and `gradle/actions/setup-gradle` actions.

* [`.github/workflows/gradle.yml`](diffhunk://#diff-0d634959c8276ae976e39ba475e63d0b9ec27824470c79f1971f58fe37c46325R1-R44): This workflow is triggered on every push to the repository. It builds the Java project with Gradle and caches/restores any dependencies to improve the workflow execution time. The workflow runs on the latest version of Ubuntu and requires read permissions for contents and issues, and write permissions for checks and pull-requests. It sets up JDK 17 and uses the `actions/setup-java` and `gradle/gradle-build-action` actions. It also publishes test results using the `EnricoMi/publish-unit-test-result-action` action.