### PR TITLE
Get timers func added

### DIFF
--- a/Time/src/main/java/com/dandd/time/domain/ITimer.kt
+++ b/Time/src/main/java/com/dandd/time/domain/ITimer.kt
@@ -11,6 +11,8 @@ interface ITimer {
      */
     fun startLoopCoroutine(coroutineScope: CoroutineScope, loopDelay: Int, oneLoopDoneUnit: () -> Unit)
 
+    suspend fun getTimers(accountName: String): List<TimerEntity>
+
     /**
      * This is for UI, it cancels the timer.
      */

--- a/Time/src/main/java/com/dandd/time/internal/TimerFunctionality.kt
+++ b/Time/src/main/java/com/dandd/time/internal/TimerFunctionality.kt
@@ -41,6 +41,24 @@ internal class TimerFunctionality(
         coroutineScope.coroutineContext.cancel()
     }
 
+    override suspend fun getTimers(accountName: String): List<TimerEntity> {
+        val timers = timerDatabaseAccess.getAllTimers()
+        var correctTimers: MutableList<TimerEntity> = mutableListOf()
+        timers.forEach {
+            if (it.status == TimerStatus.ACTIVE.rawValue) {
+                val remainingTime = getNewTimeForUpdateField(it)
+                val updatedTimerEntity: TimerEntity = it.copy(
+                    remainingTime = remainingTime,
+                )
+                correctTimers.add(updatedTimerEntity)
+            }
+            else {
+                correctTimers.add(it)
+            }
+        }
+        return correctTimers
+    }
+
     /**
      * Create a timer with the given initial value.
      * @param initialTimerTime The initial value of the timer in hh:mm:ss format.

--- a/app/src/main/java/com/Dandd/timesdk/MainActivity.kt
+++ b/app/src/main/java/com/Dandd/timesdk/MainActivity.kt
@@ -99,7 +99,8 @@ class MainActivity : ComponentActivity() {
                             }
                             if (triggerGetTimersEffect.value) {
                                 LaunchedEffect(triggerGetTimersEffect.value) {
-                                    timerDatabase.getAllTimers()
+                                    var result = timerFunc.getTimers("Dan")
+                                    print("")
                                 }
                             }
                             if (triggerDeleteAlarmEffect.value) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,4 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+org.gradle.warning.mode=all

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Fri Jun 28 18:36:32 CEST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This pull request introduces a new method to retrieve timers and updates the Gradle configuration. The most important changes include adding the `getTimers` method, implementing its logic, and updating the Gradle version.

### New method to retrieve timers:

* [`Time/src/main/java/com/dandd/time/domain/ITimer.kt`](diffhunk://#diff-e93e38e44af20bbdaedc1228cee6afaf52f4e7dd1c73b3ed7ff6f4fe4ed13cc6R14-R15): Added a new `getTimers` method to the `ITimer` interface.
* [`Time/src/main/java/com/dandd/time/internal/TimerFunctionality.kt`](diffhunk://#diff-de697e3e19a6db957f369e634f4b2bd10ec02bd7b9ee8c0631b15bdba51483f4R44-R61): Implemented the `getTimers` method to retrieve and filter active timers.
* [`app/src/main/java/com/Dandd/timesdk/MainActivity.kt`](diffhunk://#diff-30306aa0d9aa622d6805ece143000e6ca7468723aa01eed73066ca371068c4e3L102-R103): Updated the `MainActivity` to use the new `getTimers` method.

### Gradle configuration updates:

* [`gradle.properties`](diffhunk://#diff-3d103fc7c312a3e136f88e81cef592424b8af2464c468116545c4d22d6edcf19R24): Enabled all Gradle warnings.
* [`gradle-wrapper.properties`](diffhunk://#diff-40640fe1078ece83d7ea8fb67daacd77923a86d13447baf9769660b3b46f2eceL4-R4): Updated the Gradle distribution URL to version 8.11.1.