### PR TITLE
updated so it now also sets epoch time correctly when updating timers…

### DIFF
--- a/Time/build.gradle.kts
+++ b/Time/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     kotlin("kapt")
 }
 
-val releaseVersion = "0.0.4"
+val releaseVersion = "0.0.5"
 val artifactIdentification = "dandamon-time"
 val githubOwner = "DSDrachmann"
 val githubProjectName = "TimerSDK"

--- a/Time/src/main/java/com/dandd/time/internal/Database/TimerDao.kt
+++ b/Time/src/main/java/com/dandd/time/internal/Database/TimerDao.kt
@@ -19,8 +19,8 @@ internal interface TimerDao {
     @Delete
     suspend fun removeTimer(timer: TimerEntity): Int
 
-    @Query("UPDATE TimerEntity SET remainingTime = :remainingTime, status = :isActive WHERE timerId = :timerId")
-    suspend fun updateTimer(remainingTime: Long, timerId: String, isActive: Int): Int
+    @Query("UPDATE TimerEntity SET remainingTime = :remainingTime, status = :isActive, initialDateForSettingTimerInEpoch = :epochTime WHERE timerId = :timerId")
+    suspend fun updateTimer(remainingTime: Long, timerId: String, isActive: Int, epochTime: Long): Int
 
     @Query("Select * FROM timerEntity")
     suspend fun getAllTimers(): List<TimerEntity>

--- a/Time/src/main/java/com/dandd/time/internal/Database/TimerDatabaseRepository.kt
+++ b/Time/src/main/java/com/dandd/time/internal/Database/TimerDatabaseRepository.kt
@@ -30,7 +30,7 @@ internal class TimerDatabaseRepository(private val database: TimerRoomDatabase):
 
     override suspend fun updateTimer(item: TimerEntity) {
         try {
-            timerDao.updateTimer(remainingTime = item.remainingTime, timerId = item.timerId, isActive = item.status)
+            timerDao.updateTimer(remainingTime = item.remainingTime, timerId = item.timerId, isActive = item.status, epochTime = item.initialDateForSettingTimerInEpoch)
         } catch (e: Exception) {
             val message = "an update related error on set a timer happened, see exception: $e, it happened on timerId: ${item.timerId} and initialValue: ${item.initialValue} and remainingTime: ${item.remainingTime}"
             throw DatabaseOperationException(message, e)

--- a/Time/src/main/java/com/dandd/time/internal/Database/TimerRoomDatabase.kt
+++ b/Time/src/main/java/com/dandd/time/internal/Database/TimerRoomDatabase.kt
@@ -4,7 +4,7 @@ import androidx.room.Database
 import androidx.room.RoomDatabase
 import com.dandd.time.domain.model.TimerEntity
 
-@Database(entities = [TimerEntity::class], version = 6, exportSchema = false)
+@Database(entities = [TimerEntity::class], version = 7, exportSchema = false)
 internal abstract class TimerRoomDatabase: RoomDatabase() {
     abstract fun timerItemDao(): TimerDao
 }

--- a/Time/src/main/java/com/dandd/time/internal/TimerFunctionality.kt
+++ b/Time/src/main/java/com/dandd/time/internal/TimerFunctionality.kt
@@ -47,7 +47,7 @@ internal class TimerFunctionality(
         var correctTimers: MutableList<TimerEntity> = mutableListOf()
 
         for (timer in timers) {
-            if(timer.initialDateForSettingTimerInEpoch < getEpochTime() + (timer.initialValue * 1000)) {
+            if(timer.initialDateForSettingTimerInEpoch < getEpochTime() + (timer.initialValue * 1000) && timer.status != TimerStatus.ACTIVE.rawValue) {
                 val preparedTimer: TimerEntity = timer.copy(
                     initialDateForSettingTimerInEpoch = getEpochTime()
                 )
@@ -70,7 +70,7 @@ internal class TimerFunctionality(
                 correctTimers.add(it)
             }
         }
-        return timers
+        return correctTimers
     }
 
     /**


### PR DESCRIPTION
… in database. the reason it is not being set originally, is because it is a copy from the alarm sdk and the alarm sdk does not need to reset them.